### PR TITLE
Encoder fallback connect to Parallax board

### DIFF
--- a/PropellerCodeForArloBot/README.md
+++ b/PropellerCodeForArloBot/README.md
@@ -35,6 +35,16 @@ I decided to use #define because these settings occur BEFORE the compiler compil
 You will need to have the Parallax ArloBot Libraries in your SimpleIDE workspace in order for this to build. Those libraries are included in this github repository, or you can get them here:
 http://forums.parallax.com/showthread.php/152636-Run-ActivityBot-C-Code-in-the-Arlo!?p=1230592&amp;amp;posted=1#post1230592
 
+## Connecting the encoders
+The encoders are supposed to be connected to the DHB10 motor board.
+However, we have experienced regular crashs of the motor board when encoders are connected to it.
+Therefore, we have made a system that allows encoders to be either connected to the motor board,
+or connected to the Propeller Activity Board WX, like:
+* Encoder left A to pin 3
+* Encoder left B to pin 2
+* Encoder right A to pin 1
+* Encoder right B to pin 0
+
 ## Calibration Required!##
 Before running this code you must "Calibrate" the ArloDrive routines.
 This actually writes a small bit of code into an area of EEPROM that is not erased by future programs that includes tick counts for the motors.

--- a/PropellerCodeForArloBot/ROSInterfaceForArloBotWithDHB10.c
+++ b/PropellerCodeForArloBot/ROSInterfaceForArloBotWithDHB10.c
@@ -105,11 +105,11 @@ I highly suggets you work through the instructions there and run the example pro
 */
 #include "arlodrive.h"
 
-// Define the encoders pins 
-#define LEFT_A 3 
-#define LEFT_B 2 
-#define RIGHT_A 1 
-#define RIGHT_B 0 
+// Define the encoders pins
+#define LEFT_A 3
+#define LEFT_B 2
+#define RIGHT_A 1
+#define RIGHT_B 0
 
 // See ~/.arlobot/per_robot_settings_for_propeller_c_code.h to adjust MAXIMUM_SPEED
 static int abd_speedLimit = MAXIMUM_SPEED;
@@ -217,11 +217,11 @@ void safetyOverride(void *par); // Use a cog to squelch incoming commands and pe
 // This can use the gyro to detect significant heading errors due to slipping wheels when an obstacle is encountered or high centered
 static int safetyOverrideStack[128]; // If things get weird make this number bigger!
 
-// Add encoders to the propeller board and start a cog to count the ticks 
-static volatile long int left_ticks = 0, right_ticks = 0; 
-static volatile int last_left_A = 2; last_right_A = 2; 
-void encoderCount(void *par); 
-static int encoderCountStack[128]; // If things get weird make this number bigger! 
+// Add encoders to the propeller board and start a cog to count the ticks
+static volatile long int left_ticks = 0, right_ticks = 0;
+static volatile int last_left_A = 2; last_right_A = 2;
+void encoderCount(void *par);
+static int encoderCountStack[128]; // If things get weird make this number bigger!
 
 int main() {
 
@@ -372,8 +372,8 @@ int main() {
     // Start the Odometry broadcast cog
     cogstart(&broadcastOdometry, NULL, fstack, sizeof fstack);
 
-    // Start the encoder cog 
-    cogstart(&encoderCount, NULL, encoderCountStack, sizeof encoderCountStack); 
+    // Start the encoder cog
+    cogstart(&encoderCount, NULL, encoderCountStack, sizeof encoderCountStack);
 
     // To hold received commands
     double CommandedVelocity = 0.0;
@@ -584,8 +584,8 @@ void broadcastOdometry(void *par) {
     dhb10_com("GOSPD 0 0\r");
     pause(dhb10OverloadPause);
     dhb10_com("RST\r");
-    left_ticks = 0; 
-    right_ticks = 0; 
+    left_ticks = 0;
+    right_ticks = 0;
     pause(dhb10OverloadPause);
 //    int acc = DHB10_ACC;
 //    int acc = DHB10_MAX_ACC;
@@ -653,22 +653,22 @@ void broadcastOdometry(void *par) {
         int dhb10_ticksLeft, dhb10_ticksRight;
         reply = dhb10_com("DIST\r");
         if (*reply == '\r') {
+          //Wrong response
           dhb10_ticksLeft = 0;
           dhb10_ticksRight = 0;
         } else {
           sscan(reply, "%d%d", &dhb10_ticksLeft, &dhb10_ticksRight);
         }
+        if (dhb10_ticksLeft != 0 || dhb10_ticksRight != 0) {
+           //Use encoder values from DHB10 motor board
+           ticksLeft = dhb10_ticksLeft;
+           ticksRight = dhb10_ticksRight;
+        } else {
+           //Use encoder values from Propeller board
+           ticksLeft = left_ticks;
+           ticksRight = right_ticks;
+        }
         //dprint(term, "d\tDIST\t%d\t%d\n", ticksLeft, ticksRight);  // For Debugging
-        if ((dhb10_ticksLeft != 0)&&(dhb10_ticksRight != 0))
-        {
-            ticksLeft = dhb10_ticksLeft; 
-            ticksRight = dhb10_ticksRight;
-        } 
-        else 
-        {
-            ticksLeft = left_ticks; 
-            ticksRight = right_ticks;    
-        } 
         pause(dhb10OverloadPause);
 
         reply = dhb10_com("SPD\r");
@@ -778,76 +778,80 @@ void broadcastOdometry(void *par) {
     }
 }
 
-void encoderCount(void *par) 
-{ 
-    while(1) 
-    { 
-        int left_A = input(LEFT_A); 
-        int left_B = input(LEFT_B); 
-        int right_A = input(RIGHT_A); 
-        int right_B = input(RIGHT_B); 
-     
-        if (last_left_A == 0) 
-        { 
-            if (left_A == 1) 
-            { 
-                if (left_B == 0) 
-                { 
-                    left_ticks++; 
-                }           
-                else  
-                { 
-                    left_ticks--; 
-                }           
-            }         
-        }  
+/**
+ * For when the encoders are connected to the Propeller board
+ * instead of being connected to the motor board.
+ */
+void encoderCount(void *par)
+{
+    while(1)
+    {
+        int left_A = input(LEFT_A);
+        int left_B = input(LEFT_B);
+        int right_A = input(RIGHT_A);
+        int right_B = input(RIGHT_B);
+
+        if (last_left_A == 0)
+        {
+            if (left_A == 1)
+            {
+                if (left_B == 0)
+                {
+                    left_ticks++;
+                }
+                else
+                {
+                    left_ticks--;
+                }
+            }
+        }
         else if (last_left_A == 1)
         {
-            if (left_A == 0) 
-            { 
-                if (left_B == 1) 
-                { 
-                    left_ticks++; 
-                }           
-                else  
-                { 
-                    left_ticks--; 
-                }           
-            }  
-        }          
-        last_left_A = left_A; 
-     
-        if (last_right_A == 0) 
-        { 
-            if (right_A == 1) 
-            { 
-                if (right_B == 0) 
-                { 
-                    right_ticks++; 
-                }           
-                else  
-                { 
-                    right_ticks--; 
-                }           
-            }         
-        }  
-        else if (last_right_A == 1) 
-        { 
-            if (right_A == 0) 
-            { 
-                if (right_B == 1) 
-                { 
-                    right_ticks++; 
-                }           
-                else  
-                { 
-                    right_ticks--; 
-                }           
-            }         
-        }  
-        last_right_A = right_A;    
-    }     
-}   
+            if (left_A == 0)
+            {
+                if (left_B == 1)
+                {
+                    left_ticks++;
+                }
+                else
+                {
+                    left_ticks--;
+                }
+            }
+        }
+        last_left_A = left_A;
+
+        if (last_right_A == 0)
+        {
+            if (right_A == 1)
+            {
+                if (right_B == 0)
+                {
+                    right_ticks++;
+                }
+                else
+                {
+                    right_ticks--;
+                }
+            }
+        }
+        else if (last_right_A == 1)
+        {
+            if (right_A == 0)
+            {
+                if (right_B == 1)
+                {
+                    right_ticks++;
+                }
+                else
+                {
+                    right_ticks--;
+                }
+            }
+        }
+        last_right_A = right_A;
+    }
+}
 
 // For ADC built into Activity Board
 /*


### PR DESCRIPTION
The encoders are supposed to be connected to the DHB10 motor board.
However, we have experienced regular crashes of the motor board when encoders are connected to it.
Therefore, we have made a system that allows encoders to be either connected to the motor board or connected to the Propeller Activity Board WX, without requiring any other change.
Connecting the encoders to the DHB10 board should work just as well/bad as before this patch.
More info in https://github.com/chrisl8/ArloBot/pull/22#issuecomment-351937920