### PR TITLE
More robust serial read

### DIFF
--- a/src/arlobot/arlobot_bringup/scripts/SerialDataGateway.py
+++ b/src/arlobot/arlobot_bringup/scripts/SerialDataGateway.py
@@ -51,21 +51,13 @@ class SerialDataGateway(object):
             raise
 
     def _Listen(self):
-        stringIO = StringIO()
         while self._KeepRunning:
             try:
-                data = self._Serial.read()
+                data = self._Serial.readline().strip()
             except:
                 rospy.loginfo("SERIAL PORT Listen Error")
                 raise
-            if data == '\r':
-                pass
-            if data == '\n':
-                self.ReceivedLineHandler(stringIO.getvalue())
-                stringIO.close()
-                stringIO = StringIO()
-            else:
-                stringIO.write(data)
+            self.ReceivedLineHandler(data)
 
     def Write(self, data):
         #AttributeError: 'SerialDataGateway' object has no attribute '_Serial'

--- a/src/arlobot/arlobot_bringup/scripts/propellerbot_node.py
+++ b/src/arlobot/arlobot_bringup/scripts/propellerbot_node.py
@@ -297,14 +297,18 @@ class PropellerComm(object):
             rospy.logwarn("Short line from Propeller board: " + str(parts_count))
             return
 
-        x = float(line_parts[1])
-        y = float(line_parts[2])
-        # 3 is odom based heading and 4 is gyro based
-        theta = float(line_parts[3])  # On ArloBot odometry derived heading works best.
-        alternate_theta = float(line_parts[4])
+        try:
+            x = float(line_parts[1])
+            y = float(line_parts[2])
+            # 3 is odom based heading and 4 is gyro based
+            theta = float(line_parts[3])  # On ArloBot odometry derived heading works best.
+            alternate_theta = float(line_parts[4])
 
-        vx = float(line_parts[5])
-        omega = float(line_parts[6])
+            vx = float(line_parts[5])
+            omega = float(line_parts[6])
+        except:
+            rospy.logwarn("Bad Propeller odometry floats")
+            return
 
         quaternion = Quaternion()
         quaternion.x = 0.0
@@ -534,7 +538,11 @@ class PropellerComm(object):
 
         try:
             sensor_data = json.loads(line_parts[7])
+            if 'p3' not in sensor_data:
+                rospy.logwarn("Incomplete Propeller JSON for PING sensors")
+                return
         except:
+            rospy.logwarn("Bad Propeller JSON for PING sensors")
             return
         self._ping_publisher.publish(line_parts[7])
         ping = [artificial_far_distance] * 10


### PR DESCRIPTION
Use readline for higher performance, and more checks in case of data corruption.
Without `readline()`, we had some significant performance problems when some other intensive processes were running on the Rasbperry Pi.