### PR TITLE
Correct logic for when no Quick Start Board is present.

### DIFF
--- a/PropellerCodeForArloBot/ROSInterfaceForArloBotWithDHB10.c
+++ b/PropellerCodeForArloBot/ROSInterfaceForArloBotWithDHB10.c
@@ -140,10 +140,12 @@ static int fstack[256]; // If things get weird make this number bigger!
 // int and long are the same in Propeller, but linters don't like using strtol on int
 static long pingArray[NUMBER_OF_PING_SENSORS] = {0};
 static long irArray[NUMBER_OF_IR_SENSORS] = {0};
-#ifdef hasLEDs
+#ifdef hasButtons
 static long buttonArray[NUMBER_OF_BUTTON_SENSORS] = {0};
 #endif
+#ifdef hasLEDs
 static long ledArray[NUMBER_OF_LEDS] = {0};
+#endif
 #ifdef hasFloorObstacleSensors
 static int floorArray[NUMBER_OF_FLOOR_SENSORS] = {0};
 #endif
@@ -219,7 +221,7 @@ static int safetyOverrideStack[128]; // If things get weird make this number big
 
 // Add encoders to the propeller board and start a cog to count the ticks
 static volatile long int left_ticks = 0, right_ticks = 0;
-static volatile int last_left_A = 2; last_right_A = 2;
+static volatile int last_left_A = 2, last_right_A = 2;
 void encoderCount(void *par);
 static int encoderCountStack[128]; // If things get weird make this number bigger!
 
@@ -465,7 +467,9 @@ int main() {
                 int ledNumber = strtod(token, &unconverted);
                 token = strtok(NULL, delimiter);
                 int ledState = strtod(token, &unconverted);
+#ifdef hasLEDs
                 ledArray[ledNumber] = ledState;
+#endif
                 timeoutCounter = 0;
             } else if (buf[0] == 'p') {
                 //Update the X, Y position and heading
@@ -611,8 +615,8 @@ void broadcastOdometry(void *par) {
     int ticksLeft = 0, ticksRight = 0, ticksLeftOld, ticksRightOld;
     double deltaDistance, deltaTheta, deltaX, deltaY, V, Omega;
     int speedLeft, speedRight, throttleStatus = 0, deltaTicksLeft, deltaTicksRight;
-    double leftMotorPower;
-    double rightMotorPower;
+    double leftMotorPower = DEFAULT_MOTOR_ADC_VOLTAGE;
+    double rightMotorPower = DEFAULT_MOTOR_ADC_VOLTAGE;
     int newLeftSpeed = 0, newRightSpeed = 0, oldLeftSpeed = 0, oldRightSpeed = 0;
 
     int dt = CLKFREQ / 10;
@@ -1043,7 +1047,7 @@ void pollGyro(void *par) {
    1. Make sure output sensor readings to ROS are near real time.
    2. Make sure "escape" operations are fast and accurate.
    */
-    void safetyOverride(void *par) {
+void safetyOverride(void *par) {
 
    void setEscapeSpeeds(int left, int right) {
        escapeLeftSpeed = left;

--- a/PropellerCodeForArloBot/dotfiles/per_robot_settings_for_propeller_c_code.h
+++ b/PropellerCodeForArloBot/dotfiles/per_robot_settings_for_propeller_c_code.h
@@ -181,6 +181,10 @@ If you don't want to do this, just comment this setting out:
 // If these get flipped just flip the wires, or the numbers.
 #define LEFT_MOTOR_ADC_PIN 0
 #define RIGHT_MOTOR_ADC_PIN 1
+// Value for reported left and right motor ADC voltage when hasMotorPowerMonitorCircuit is not defined.
+// A value less than 1 will prevent the robot from moving under ROS control in propellerbot_node.py unless that file is modified.   
+// In propellerbot_node.py, the ratio 15/4.69 is used to convert the right motor ADC voltage to measured and reported robot battery voltage. 
+#define DEFAULT_MOTOR_ADC_VOLTAGE (12.0 *(4.69/15.0))
 
 // CLIFF SENSORS:
 // QUESTION: Do you have IR "cliff" sensors mounted to the front of the robot?
@@ -198,6 +202,16 @@ If you don't want to do this, just comment this setting out:
 //#define hasFloorObstacleSensors
 #define FIRST_FLOOR_SENSOR_PIN 7
 #define NUMBER_OF_FLOOR_SENSORS 4
+
+// Buttons:
+// QUESTION: Do you have button sensors on the robot?
+// #define hasButtons
+#define NUMBER_OF_BUTTON_SENSORS 0
+
+// LEDs:
+// QUESTION: Do you have LEDs on the robot?
+// #define hasLEDs
+#define NUMBER_OF_LEDS 0
 
 /* END OF QUESTION SECTION!
 That is all, you are ready to attempt to build this code and load it

--- a/scripts/check_hardware.sh
+++ b/scripts/check_hardware.sh
@@ -151,17 +151,18 @@ if [ $(jq '.hasActivityBoard' ${HOME}/.arlobot/personalDataForBehavior.json) == 
         echo "and set 'hasActivityBoard' to false"
         wrap_up_on_fail
     fi
-fi
 
-# Quick Start Board
-if [ $(jq '.hasActivityBoard' ${HOME}/.arlobot/personalDataForBehavior.json) == true ]
-    then
-    echo "Checking Quick Start Board . . ."
-    ${SCRIPTDIR}/find_QuickStart.sh |grep USB &> /dev/null
-    if [ $? -gt 0 ]
+    # Quick Start Board
+    # Assumption is that Quick Start Board will only be present with Activity Board. 
+    if [ $(jq '.hasQuickStartBoard' ${HOME}/.arlobot/personalDataForBehavior.json) == true ]
         then
-        echo "Quick Start Board missing!"
-        wrap_up_on_fail
+        echo "Checking Quick Start Board . . ."
+        ${SCRIPTDIR}/find_QuickStart.sh |grep USB &> /dev/null
+        if [ $? -gt 0 ]
+            then
+            echo "Quick Start Board missing!"
+            wrap_up_on_fail
+        fi
     fi
 fi
 


### PR DESCRIPTION
1) Test for Quick Start Board was referencing .json for Activity Board. Script would crash for hardware configurations without a Quick Start board even though .json configuration specified that no Quick Start Board was present. Moved test for Quick Start Board inside of test for Activity Board to allow a board-less test configuration to be set by configuring for no Activity Board.
2) Also corrected some configuration issues that caused compile and operational  problems for a hardware configuration without a quickstart board, without LEDs and without motor voltage monitoring circuitry.