### PR TITLE
Add search for Propeller_Activity_Board to find_ActivityBoard.sh

### DIFF
--- a/scripts/find_ActivityBoard.sh
+++ b/scripts/find_ActivityBoard.sh
@@ -11,3 +11,7 @@ SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 # echo ${SCRIPTDIR} # For debugging
 
 node ${SCRIPTDIR}/../node/UsbDevice.js "Propeller_Activity_Brd" ID_MODEL
+if [ $? -ne 0 ]; then
+  echo "Could not find 'Propeller_Activity_Brd', trying 'Propeller_Activity_Board'."
+  node ${SCRIPTDIR}/../node/UsbDevice.js "Propeller_Activity_Board" ID_MODEL
+fi


### PR DESCRIPTION
find_ActivityBoard.sh searches for a "Propeller_Activity_Brd". 
The Propeller Activity Board WX that was included with my Arlobot Complete kit shows up as a "Propeller_Activity_Board".
Modified find_ActivityBoard.sh to search for a "Propeller_Activity_Board" if the search for a "Propeller_Activity_Brd" fails, in order to support both potential names.