### PR TITLE
Correct find_ActivityBoard.sh such that it works with direct2PropSerialTest.sh...

### DIFF
--- a/scripts/find_ActivityBoard.sh
+++ b/scripts/find_ActivityBoard.sh
@@ -9,9 +9,20 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 # echo ${SCRIPTDIR} # For debugging
-
-node ${SCRIPTDIR}/../node/UsbDevice.js "Propeller_Activity_Brd" ID_MODEL
-if [ $? -ne 0 ]; then
-  echo "Could not find 'Propeller_Activity_Brd', trying 'Propeller_Activity_Board'."
+#
+# This script is called by check_hardware.sh and direct2PropSerialTest.sh
+# In order for it to work properly with direct2PropSerialTest.sh, it must ONLY write
+# USB device information to the standard output (STDOUT).
+# Therefore, in order to sucessfully search for two potential Propeller_Activity_[Brd|Board] types,
+# the first search must only write to STDOUT if it is going to be successful.
+#
+# Prevent output to STDOUT and determine whether a "Propeller_Activity_Brd" will be found.
+node ${SCRIPTDIR}/../node/UsbDevice.js "Propeller_Activity_Brd" ID_MODEL|grep USB &>/dev/null
+if [ $? -eq 0 ]; then
+  # "Propeller_Activity_Brd" will be found, so repeat command with result going to STDOUT.
+  node ${SCRIPTDIR}/../node/UsbDevice.js "Propeller_Activity_Brd" ID_MODEL
+else
+  # "Propeller_Activity_Brd" will not be found, so try "Propeller_Activity_Board".
+  # echo "Could not find 'Propeller_Activity_Brd', trying 'Propeller_Activity_Board'."
   node ${SCRIPTDIR}/../node/UsbDevice.js "Propeller_Activity_Board" ID_MODEL
 fi


### PR DESCRIPTION
… when robot has a "Propeller_Activity_Board" instead of a "Propeller_Activity_Brd".

This was discovered during an investigation of issue #35. 
direct2PropSerialTest.sh does not work properly when robot has a "Propeller_Activity_Board" because a failed check for a "Propeller_Activity_Brd" in find_ActivityBoard.sh results in an error message being written to STDOUT which gets interpreted by the terminal command in direct2PropSerialTest.sh as the baud rate, resulting in an error.